### PR TITLE
Make a little more user friendly - click click

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,30 +2,14 @@ Setup Syncthing on Kindle Touch
 ==========================
 
 1. You need jailbreak and [KULA](http://www.mobileread.com/forums/showthread.php?t=203326) first.
-2. Download this [repository](https://github.com/gutenye/syncthing-kindle/archive/master.zip)
-3. Download [syncthing-linux-arm](https://github.com/syncthing/syncthing/releases) and copy `syncthing` binary to `syncthing/bin/`
-4. Connect Kindle Touch to Your PC
-5. Copy `syncthing/` to `KINDLE-ROOT/extensions/syncthing/`
-6. [SSH into your Kindle](http://www.mobileread.com/forums/showthread.php?t=186645)
-7. Open [firewall ports](https://github.com/syncthing/syncthing/wiki/Firewalls-and-Port-Forwards#local-firewall)
-
-```
-# mntroot rw
-# vi /etc/sysconfig/iptables
-  -A INPUT -p tcp --dport 8080 -j ACCEPT
-  -A INPUT -p tcp --dport 22000 -j ACCEPT
-  -A INPUT -p udp --dport 21025 -j ACCEPT
-# iptables-restore < /etc/sysconfig/iptables
-# mntroot ro
-```
-8\. Start syncthing for the first time, and enable [access the web GUI from other computers](https://github.com/syncthing/syncthing/wiki/Firewalls-and-Port-Forwards#remote-web-gui)
-
-```
-# /mnt/us/extensions/syncthing/bin/syncthing -home=/mnt/us/extensions/syncthing/config
-# vi /mnt/us/extensions/syncthing/config/config.xml
-  <gui enabled="true" tls="false">
-     <address>0.0.0.0:8080</address>
-```
-9\. Find out your Kindle IP address by type `;711` in search, then open `http://IP-ADDRESS:8080` in your browser. <br>
-10\. Ignore kindle auto generated index files: `*.sdr`
-11\. Note: connect kindle to computer or restart kindle will terminate syncthing process.
+1. Download this [repository](https://github.com/gutenye/syncthing-kindle/archive/master.zip)
+1. Download [syncthing-linux-arm](https://github.com/syncthing/syncthing/releases) and copy `syncthing` binary to `syncthing/bin/`
+1. Connect Kindle Touch to Your PC
+1. Copy `syncthing/` to `KINDLE-ROOT/extensions/syncthing/`
+1. Select "Open Firewall for Kindle" from KUAL
+1. Select "Start Syncthing INSECURE Admin" from KUAL
+1. Find out your Kindle IP address by type `;711` in search, then open `http://IP-ADDRESS:8080` in your browser. <br>
+1. Configure all peers and folders
+1. Ignore kindle auto generated index files: `*.sdr`
+1. Select "Stop Syncthing" and then "Start Syncthing" from KUAL
+1. Note: connect kindle to computer or restart kindle will terminate syncthing process and firewall.

--- a/syncthing/menu.json
+++ b/syncthing/menu.json
@@ -6,7 +6,9 @@
 		"items": [
 			{"name": "Start Syncthing", "priority": 1, "action": "/mnt/us/extensions/syncthing/bin/syncthing -home=/mnt/us/extensions/syncthing/config &>/mnt/us/syncthing.log"},
 			{"name": "Stop Syncthing", "priority": 2, "action": "killall syncthing"},
-			{"name": "Restart Syncthing", "priority": 3, "action": "killall syncthing; /mnt/us/extensions/syncthing/bin/syncthing -home=/mnt/us/extensions/syncthing/config &> /mnt/us/syncthing.log"}
+			{"name": "Restart Syncthing", "priority": 3, "action": "killall syncthing; /mnt/us/extensions/syncthing/bin/syncthing -home=/mnt/us/extensions/syncthing/config &> /mnt/us/syncthing.log"},
+			{"name": "Open Firewall for Syncthing", "priority": 4, "action": "iptables -A INPUT -i wlan0 -p tcp --dport 8080 -j ACCEPT; iptables -A INPUT -i wlan0 -p tcp --dport 22000 -j ACCEPT; iptables -A INPUT -i wlan0 -p tcp --dport 21025 -j ACCEPT; "},
+			{"name": "Start Syncthing INSECURE Admin", "priority": 5, "action": "/mnt/us/extensions/syncthing/bin/syncthing -home=/mnt/us/extensions/syncthing/config -gui-address 'http://0.0.0.0:8080' -no-restart &>/mnt/us/syncthing.log"}
 		  ]
 		}
 	]


### PR DESCRIPTION
Not sure if you want this exactly, or if you would like to adjust it a bit, but it's much easier to never have to ssh in and to be explicit about opening the firewall when you start syncthing.

Other options
* Add the iptables commands to the start (-A to add) and stop (-D to delete) syncthing commands.
* Keep the admin interface insecure, but that seems super insecure.